### PR TITLE
Fix import module six

### DIFF
--- a/rest_assured/testcases.py
+++ b/rest_assured/testcases.py
@@ -1,10 +1,10 @@
 from django.db.models import Manager
 from django.core.exceptions import ObjectDoesNotExist
-from django.utils import six
+import six
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
-from django.utils.six import text_type
+from six import text_type
 
 
 class BaseRESTAPITestCase(APITestCase):


### PR DESCRIPTION
Fix import module six to support Django versions >= 3.0, because django.utils.six module was removed from django-3.0